### PR TITLE
支持上屏后预测

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -19,6 +19,8 @@ switcher:
     - ascii_punct
     - traditionalization
     - emoji_suggestion
+    - prediction
+    - predict_simp_switch
   fold_options: true
   abbreviate_options: true
   option_list_separator: "/"

--- a/lufs_flypy.schema.yaml
+++ b/lufs_flypy.schema.yaml
@@ -30,11 +30,9 @@ switches:
   - name: prediction
     abbrev: [止, 预]
     states: [关闭预测, 开启预测]
-    reset: 0 #根据需要调整预测默认状态，0 关闭 1 开启
   - name: predict_simp_switch #参考fxliang大佬的方案，由于预测词库为繁体，可能是因为没有繁体转简体所以才需要这个开关
     abbrev: [繁, 简]
     states: [繁体预测, 简体预测]
-    reset: 1
 
 engine:
   processors:

--- a/lufs_flypy.schema.yaml
+++ b/lufs_flypy.schema.yaml
@@ -28,12 +28,12 @@ switches:
     # reset: 1 # 默认状态: 0 关闭 1 开启
     states: [🈚️️, 🈶️]
   - name: prediction
-    abbrev: [止, 联]
-    states: [不联想, 联想]
-    reset: 0 #根据需要调整联想默认状态
-  - name: predict_simp_switch #参考fxliang大佬的方案，由于联想词库为繁体，可能是因为没有繁体转简体所以才需要这个开关
+    abbrev: [止, 预]
+    states: [关闭预测, 开启预测]
+    reset: 0 #根据需要调整预测默认状态，0 关闭 1 开启
+  - name: predict_simp_switch #参考fxliang大佬的方案，由于预测词库为繁体，可能是因为没有繁体转简体所以才需要这个开关
     abbrev: [繁, 简]
-    states: [繁体联想, 简体联想]
+    states: [繁体预测, 简体预测]
     reset: 1
 
 engine:
@@ -85,7 +85,7 @@ predict_simp:
   option_name: predict_simp_switch
 
 predictor:
-  db: predict.db # predict db file in user directory/shared directory
+  db: predict.db # 文件名，predict db file in user directory/shared directory
   max_candidates: 5 #每次预测的最大候选项数量，0表示全部候选项
   max_iterations: 1 #最大预测次数，0表示不限制
 

--- a/lufs_flypy.schema.yaml
+++ b/lufs_flypy.schema.yaml
@@ -27,10 +27,19 @@ switches:
   - name: emoji_suggestion
     # reset: 1 # 默认状态: 0 关闭 1 开启
     states: [🈚️️, 🈶️]
+  - name: prediction
+    abbrev: [止, 联]
+    states: [不联想, 联想]
+    reset: 0 #根据需要调整联想默认状态
+  - name: predict_simp_switch #参考fxliang大佬的方案，由于联想词库为繁体，可能是因为没有繁体转简体所以才需要这个开关
+    abbrev: [繁, 简]
+    states: [繁体联想, 简体联想]
+    reset: 1
 
 engine:
   processors:
     # - ascii_composer # Windows 用户请解除此行注释，否则将会无法切换到英文输入
+    - predictor
     - recognizer
     - lua_processor@select_character # lua 选词扩展，如需关闭请注释
     - key_binder
@@ -46,6 +55,7 @@ engine:
     - punct_segmentor
     - fallback_segmentor
   translators:
+    - predict_translator
     - punct_translator
     - lua_translator@date_translator # 动态日期时间输入
     - lua_translator@unicode_input # Unicode 输入支持
@@ -53,6 +63,7 @@ engine:
     - script_translator
   filters:
     - simplifier@emoji_suggestion
+    - simplifier@predict_simp # 繁体转换为简体
     - simplifier@traditionalize # 简繁转化
     - uniquifier # 去重
     # - lua_filter@long_phrase_first # 最长词组和单字在先
@@ -68,6 +79,15 @@ emoji_suggestion:
   opencc_config: emoji.json
   option_name: emoji_suggestion
   tips: false
+
+predict_simp:
+  opencc_config: t2s.json
+  option_name: predict_simp_switch
+
+predictor:
+  db: predict.db # predict db file in user directory/shared directory
+  max_candidates: 5 #每次预测的最大候选项数量，0表示全部候选项
+  max_iterations: 1 #最大预测次数，0表示不限制
 
 speller:
   alphabet: zyxwvutsrqponmlkjihgfedcba/


### PR DESCRIPTION
参考 fxliang 大大的 [配置文件](https://github.com/fxliang/weasel_config) 与 [librime-predict](https://github.com/rime/librime-predict) 的说明

联想似乎还不支持更多的自定义设置